### PR TITLE
Add Custom API Server Endpoint Support

### DIFF
--- a/src/action.go
+++ b/src/action.go
@@ -1069,9 +1069,10 @@ func runInteractiveSession() {
 			model = "claude-3-5-sonnet-20241022"
 		}
 		claudeConfig = &ClaudeConfig{
-			APIKey:    apiKey,
-			Model:     model,
-			MaxTokens: 1024,
+			APIKey:     apiKey,
+			APIBaseURL: os.Getenv("OPS0_API_BASE_URL"),
+			Model:      model,
+			MaxTokens:  1024,
 		}
 		fmt.Println("🧠 AI mode enabled in interactive session")
 	}

--- a/src/ansible.go
+++ b/src/ansible.go
@@ -80,9 +80,10 @@ Respond in this format:
 
 User request: ` + userMsg
 	claudeConfig := &ClaudeConfig{
-		APIKey: apiKey,
-		Model:  "claude-3-5-sonnet-20241022",
-		MaxTokens: 1024,
+		APIKey:     apiKey,
+		APIBaseURL: os.Getenv("OPS0_API_BASE_URL"),
+		Model:      "claude-3-5-sonnet-20241022",
+		MaxTokens:  1024,
 	}
 	response := callClaude(claudeConfig, prompt, "")
 	if response == "" {

--- a/src/definitions.go
+++ b/src/definitions.go
@@ -14,8 +14,9 @@ const (
 
 // Claude API configuration
 type ClaudeConfig struct {
-	APIKey string
-	Model  string
+	APIKey     string
+	APIBaseURL string
+	Model      string
 	MaxTokens int
 }
 

--- a/src/llms.go
+++ b/src/llms.go
@@ -31,7 +31,12 @@ func callClaude(config *ClaudeConfig, systemPrompt, userMessage string) string {
 		return ""
 	}
 
-	req, err := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", bytes.NewBuffer(jsonData))
+	apiURL := config.APIBaseURL
+	if apiURL == "" {
+		apiURL = "https://api.anthropic.com"
+	}
+	
+	req, err := http.NewRequest("POST", apiURL+"/v1/messages", bytes.NewBuffer(jsonData))
 	if err != nil {
 		fmt.Printf("⚠️  ops0: Error creating AI request: %v\n", err)
 		return ""
@@ -83,8 +88,9 @@ func getClaudeConfigIfAvailable() *ClaudeConfig {
 		model = "claude-3-5-sonnet-20241022"
 	}
 	return &ClaudeConfig{
-		APIKey:    apiKey,
-		Model:     model,
-		MaxTokens: 1024,
+		APIKey:     apiKey,
+		APIBaseURL: os.Getenv("OPS0_API_BASE_URL"),
+		Model:      model,
+		MaxTokens:  1024,
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -96,9 +96,10 @@ func main() {
 			model = "claude-3-5-sonnet-20241022"
 		}
 		claudeConfig = &ClaudeConfig{
-			APIKey:    apiKey,
-			Model:     model,
-			MaxTokens: 1024,
+			APIKey:     apiKey,
+			APIBaseURL: os.Getenv("OPS0_API_BASE_URL"),
+			Model:      model,
+			MaxTokens:  1024,
 		}
 		fmt.Println("🧠 ops0: AI mode enabled")
 	} else if aiMode {


### PR DESCRIPTION
## Summary

This PR adds support for configurable API server endpoints through the `OPS0_API_BASE_URL` environment variable, enabling users to connect to custom Claude-compatible API services while maintaining full backward compatibility.

## Changes

### Core Implementation

- **`definitions.go`**: Added `APIBaseURL` field to `ClaudeConfig` struct
- **`llms.go`**: Updated `callClaude()` to use configurable endpoint with fallback to default
- **`main.go`**: Added `OPS0_API_BASE_URL` environment variable reading
- **`action.go`**: Updated interactive mode configuration
- **`ansible.go`**: Updated Ansible AI integration configuration

### Key Features

1. **Configurable Endpoint**: Set custom API server via `OPS0_API_BASE_URL`
2. **Backward Compatible**: Defaults to `https://api.anthropic.com` when not set
3. **Consistent Naming**: Follows existing `OPS0_*` environment variable convention
4. **Cross-Platform**: Works on all supported platforms (macOS, Linux, Windows)

## Usage Examples

### Default Behavior (Unchanged)
```bash
export ANTHROPIC_API_KEY=sk-xxx
ops0 -m "show docker containers" -ai
```

### Custom API Endpoint
```bash
export ANTHROPIC_API_KEY=sk-xxx
export OPS0_API_BASE_URL=https://api.custom-provider.com
export OPS0_AI_MODEL=custom-model-name
ops0 -m "show docker containers" -ai
```

## Testing

✅ **Compilation**: All platforms compile successfully
- macOS ARM64
- Linux x86_64  
- Linux ARM64
- Windows x86_64

✅ **Functionality**: Tested with both default and custom endpoints
- Default Anthropic API works unchanged
- Custom API endpoint correctly used
- Chinese language support maintained
- All existing features preserved

✅ **Environment Variables**: Complete configuration support
```bash
export ANTHROPIC_API_KEY=sk-xxx
export OPS0_API_BASE_URL=https://openrouter.ai/api
export OPS0_AI_MODEL=anthropic/claude-3.5-sonnet
```

## Benefits

- **Enterprise Ready**: Supports corporate proxies and custom gateways
- **Provider Flexibility**: Works with any Claude-compatible API service
- **Regional Support**: Enables use of regional endpoints for compliance/latency
- **Development Friendly**: Useful for testing with local API servers

## Backward Compatibility

This change is 100% backward compatible:
- Existing users see no change in behavior
- No breaking changes to existing environment variables
- Default API endpoint remains `https://api.anthropic.com`

Closes #9
